### PR TITLE
Fixes incorrect stylesheet file loading paths

### DIFF
--- a/lib/generators/foundation/install_generator.rb
+++ b/lib/generators/foundation/install_generator.rb
@@ -16,7 +16,7 @@ module Foundation
         append_to_file File.join(javascripts_base_dir, "application#{detect_js_format[0]}"), "#{detect_js_format[2]}"
         settings_file = File.join(File.dirname(__FILE__),"..", "..", "..", "vendor", "assets", "stylesheets", "foundation", "settings", "_settings.scss")
         create_file File.join(stylesheets_base_dir, 'foundation_and_overrides.scss'), File.read(settings_file)
-        append_to_file File.join(stylesheets_base_dir, 'foundation_and_overrides.scss'), "\n@import 'foundation';\n"
+        append_to_file File.join(stylesheets_base_dir, 'foundation_and_overrides.scss'), "\n@import 'foundation/foundation';\n"
         insert_into_file File.join(stylesheets_base_dir, "application#{detect_css_format[0]}"), "\n#{detect_css_format[1]} require foundation_and_overrides\n", :after => "require_self"
       end
 

--- a/lib/generators/foundation/install_generator.rb
+++ b/lib/generators/foundation/install_generator.rb
@@ -14,7 +14,7 @@ module Foundation
         # gsub_file "app/assets/javascripts/application#{detect_js_format[0]}", /\/\/= require jquery\n/, ""
         insert_into_file File.join(javascripts_base_dir, "application#{detect_js_format[0]}"), "#{detect_js_format[1]} require foundation\n", :after => "jquery_ujs\n"
         append_to_file File.join(javascripts_base_dir, "application#{detect_js_format[0]}"), "#{detect_js_format[2]}"
-        settings_file = File.join(File.dirname(__FILE__),"..", "..", "..", "vendor", "assets", "stylesheets", "foundation", "_settings.scss")
+        settings_file = File.join(File.dirname(__FILE__),"..", "..", "..", "vendor", "assets", "stylesheets", "foundation", "settings", "_settings.scss")
         create_file File.join(stylesheets_base_dir, 'foundation_and_overrides.scss'), File.read(settings_file)
         append_to_file File.join(stylesheets_base_dir, 'foundation_and_overrides.scss'), "\n@import 'foundation';\n"
         insert_into_file File.join(stylesheets_base_dir, "application#{detect_css_format[0]}"), "\n#{detect_css_format[1]} require foundation_and_overrides\n", :after => "require_self"

--- a/vendor/assets/stylesheets/foundation/settings/_settings.scss
+++ b/vendor/assets/stylesheets/foundation/settings/_settings.scss
@@ -39,7 +39,7 @@
 //  34. Tooltip
 //  35. Top Bar
 
-@import 'util/util';
+@import 'foundation/util/util';
 
 // 1. Global
 // ---------
@@ -544,4 +544,3 @@ $topbar-padding: 0.5rem;
 $topbar-background: $light-gray;
 $topbar-link-color: $primary-color;
 $topbar-input-width: 200px;
-


### PR DESCRIPTION
5edd664 - There is an error during foundation:install that is caused by this load path, the install can now complete with this fix

c5fdd99 - A rails error is thrown due to the `@import "utils/utils"` and `@import "foundation"` in the foundation_and_overrides file, it needs to look one level deeper with the foundation folder. (i.e. "foundation/foundation") 
